### PR TITLE
Fix/frontier block import

### DIFF
--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -59,7 +59,6 @@ use sp_runtime::{app_crypto::AppCrypto, traits::BlakeTwo256};
 use substrate_prometheus_endpoint::Registry;
 
 // Frontier
-use fc_consensus::FrontierBlockImport;
 use fc_mapping_sync::{kv::MappingSyncWorker, SyncStrategy};
 use fc_rpc::EthTask;
 use fc_rpc_core::types::{FeeHistoryCache, FilterPool};
@@ -106,6 +105,7 @@ type ParachainExecutor<Executor> = NativeElseWasmExecutor<Executor>;
 pub type ParachainClient<RuntimeApi, Executor> =
 	TFullClient<Block, RuntimeApi, ParachainExecutor<Executor>>;
 type ParachainBackend = TFullBackend<Block>;
+// Does NOT have FrontierBlockImport for the following issue: https://github.com/paritytech/frontier/issues/603
 type ParachainBlockImport<RuntimeApi, Executor> = TParachainBlockImport<
 	Block,
 	Arc<TFullClient<Block, RuntimeApi, ParachainExecutor<Executor>>>,

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -108,11 +108,7 @@ pub type ParachainClient<RuntimeApi, Executor> =
 type ParachainBackend = TFullBackend<Block>;
 type ParachainBlockImport<RuntimeApi, Executor> = TParachainBlockImport<
 	Block,
-	FrontierBlockImport<
-		Block,
-		Arc<TFullClient<Block, RuntimeApi, ParachainExecutor<Executor>>>,
-		TFullClient<Block, RuntimeApi, ParachainExecutor<Executor>>,
-	>,
+	Arc<TFullClient<Block, RuntimeApi, ParachainExecutor<Executor>>>,
 	ParachainBackend,
 >;
 
@@ -203,9 +199,7 @@ where
 
 	let frontier_backend = crate::rpc::open_frontier_backend(client.clone(), config)?;
 
-	let frontier_block_import = FrontierBlockImport::new(client.clone(), client.clone());
-
-	let parachain_block_import = TParachainBlockImport::new(frontier_block_import, backend.clone());
+	let parachain_block_import = TParachainBlockImport::new(client.clone(), backend.clone());
 
 	let import_queue = build_import_queue(
 		client.clone(),


### PR DESCRIPTION
Frontier / EVM was not present at Genesis. So, when a collator is syncing it will reject blocks due to an Ethereum block not being found. This is outlined in the following issue: https://github.com/paritytech/frontier/issues/603.

This PR solves the issues by removing the `FrontierBlockImport` wrapper. The `MappingSyncWorker` for Frontier is still present.