### PR TITLE
feat: add try-runtime to ci

### DIFF
--- a/.github/workflows/try-runtime-devnet.yml
+++ b/.github/workflows/try-runtime-devnet.yml
@@ -1,0 +1,51 @@
+# Test storage migration using try-runtume on PRs with label "migration-devnet"
+name: Test storage migration
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+  push:
+    branches: [ main ]
+
+jobs:
+  try_runtime:
+    if: contains(github.event.pull_request.labels.*.name, 'migration-devnet')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install protoc
+        run: |
+          sudo apt-get install -y protobuf-compiler
+          protoc --version
+      - name: Rust Setup
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          override: true
+          components: rustfmt, clippy
+
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Set up cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - run: |
+          cargo run -p watr-node --locked --release --no-default-features --features try-runtime try-runtime \
+              --runtime ./target/release/wbuild/watr-devnet-runtime/target/wasm32-unknown-unknown/release/watr_devnet_runtime.wasm \
+              -lruntime=debug \
+              --chain=devnet-dev \
+              on-runtime-upgrade live --uri wss://rpc.dev.watr.org:443
+        env:
+          RUST_LOG: remote-ext=debug,runtime=debug


### PR DESCRIPTION
This PR adds a CI step to check whether there exist pending migrations in a given chain where the project is deployed. For now it only includes the devnet runtime on Rococo.

### Trigger

The Ci step can be triggered upon addition of the `migration-devnet` PR label. It is also expected to use Parity's bot in the near future.

Sample output:

![Screenshot 2023-08-25 at 14 47 10](https://github.com/Watr-Protocol/watr/assets/2722756/6d2439a4-71a0-4eb7-a2d8-4a43e58491ff)
