### PR TITLE
refactor: try-runtime client

### DIFF
--- a/.github/workflows/try-runtime-devnet.yml
+++ b/.github/workflows/try-runtime-devnet.yml
@@ -41,11 +41,12 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
+      - name: Install try-runtime
+        run: cargo install --git https://github.com/paritytech/try-runtime-cli --locked
+
       - run: |
-          cargo run -p watr-node --locked --release --no-default-features --features try-runtime try-runtime \
-              --runtime ./target/release/wbuild/watr-devnet-runtime/target/wasm32-unknown-unknown/release/watr_devnet_runtime.wasm \
-              -lruntime=debug \
-              --chain=devnet-dev \
+          cargo build -p watr-node --locked --release --no-default-features --features try-runtime && \
+          try-runtime --runtime ./target/release/wbuild/watr-devnet-runtime/target/wasm32-unknown-unknown/release/watr_devnet_runtime.wasm \
               on-runtime-upgrade live --uri wss://rpc.dev.watr.org:443
         env:
           RUST_LOG: remote-ext=debug,runtime=debug

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -55,14 +55,6 @@ pub enum Subcommand {
 	#[command(subcommand)]
 	Benchmark(frame_benchmarking_cli::BenchmarkCmd),
 
-	/// Try some testing command against a specified runtime state.
-	#[cfg(feature = "try-runtime")]
-	TryRuntime(try_runtime_cli::TryRuntimeCmd),
-
-	/// Errors since the binary was not build with `--features try-runtime`.
-	#[cfg(not(feature = "try-runtime"))]
-	TryRuntime,
-
 	/// Key management cli utilities
 	#[command(subcommand)]
 	Key(sc_cli::KeySubcommand),

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -371,49 +371,6 @@ pub fn run() -> Result<()> {
 				_ => Err("Benchmarking sub-command unsupported".into()),
 			}
 		},
-		#[cfg(feature = "try-runtime")]
-		Some(Subcommand::TryRuntime(cmd)) => {
-			use sc_executor::{sp_wasm_interface::ExtendedHostFunctions, NativeExecutionDispatch};
-			use try_runtime_cli::block_building_info::timestamp_with_aura_info;
-			use watr_common::MILLISECS_PER_BLOCK;
-
-			let runner = cli.create_runner(cmd)?;
-
-			type HostFunctionsOf<E> = ExtendedHostFunctions<
-				sp_io::SubstrateHostFunctions,
-				<E as NativeExecutionDispatch>::ExtendHostFunctions,
-			>;
-
-			// grab the task manager.
-			let registry = &runner.config().prometheus_config.as_ref().map(|cfg| &cfg.registry);
-			let task_manager =
-				sc_service::TaskManager::new(runner.config().tokio_handle.clone(), *registry)
-					.map_err(|e| format!("Error: {:?}", e))?;
-
-			let info_provider = timestamp_with_aura_info(MILLISECS_PER_BLOCK);
-			match runner.config().chain_spec.runtime() {
-				Runtime::Devnet | Runtime::Default => runner.async_run(|_| {
-					Ok((
-						cmd.run::<Block, HostFunctionsOf<WatrDevnetRuntimeExecutor>, _>(Some(
-							info_provider,
-						)),
-						task_manager,
-					))
-				}),
-				Runtime::Mainnet => runner.async_run(|_| {
-					Ok((
-						cmd.run::<Block, HostFunctionsOf<WatrRuntimeExecutor>, _>(Some(
-							info_provider,
-						)),
-						task_manager,
-					))
-				}),
-			}
-		},
-		#[cfg(not(feature = "try-runtime"))]
-		Some(Subcommand::TryRuntime) => Err("Try-runtime was not enabled when building the node. \
-			You can enable it with `--features try-runtime`."
-			.into()),
 		Some(Subcommand::Key(cmd)) => cmd.run(&cli),
 		None => {
 			let runner = cli.create_runner(&cli.run.normalize())?;


### PR DESCRIPTION
This PR uses the [try-runtime client](https://github.com/paritytech/try-runtime-cli) instead of the built-in try-runtime command, as using the client is the new recommended way to execute try-runtime.